### PR TITLE
implement interrupt read for palm connection info

### DIFF
--- a/include/pi-usb.h
+++ b/include/pi-usb.h
@@ -55,6 +55,8 @@ extern "C" {
 		int (*control_request) PI_ARGS((struct pi_usb_data *usb_data,
 			int request_type, int request, int value, int reqindex,
 			void *data, int size, int timeout));
+		int (*interrupt_read) PI_ARGS((struct pi_usb_data *usb_data,
+			int ep, void *data, int size, int timeout));
 	} pi_usb_impl_t;
 
 #define USB_INIT_NONE		(1<<0)

--- a/libpisock/darwinusb.c
+++ b/libpisock/darwinusb.c
@@ -1958,6 +1958,7 @@ pi_usb_impl_init (struct pi_usb_impl *impl)
 	impl->wait_for_device	= u_wait_for_device;
 	impl->changebaud	= u_changebaud;
 	impl->control_request	= NULL;   /* that is, until we factor out common code */
+	impl->interrupt_read = NULL;
 }
 
 /* vi: set ts=8 sw=4 sts=4 noexpandtab: cin */

--- a/libpisock/freebsdusb.c
+++ b/libpisock/freebsdusb.c
@@ -68,6 +68,7 @@ void pi_usb_impl_init (struct pi_usb_impl *impl)
 	impl->read 	= u_read;
 	impl->flush	= u_flush;
 	impl->poll 	= u_poll;
+	impl->interrupt_read = NULL;
 }
 
 

--- a/libpisock/libusb.c
+++ b/libpisock/libusb.c
@@ -62,6 +62,8 @@ static int u_wait_for_device(struct pi_socket *ps, int *timeout);
 static int u_flush(pi_socket_t *ps, int flags);
 static int u_control_request (pi_usb_data_t *usb_data, int request_type, 
 	int request, int value, int control_index, void *data, int size, int timeout);
+static int u_interrupt_read (pi_usb_data_t *usb_data, int ep, void *data, int size,
+	int timeout);
 
 void pi_usb_impl_init (struct pi_usb_impl *impl)
 {
@@ -74,6 +76,7 @@ void pi_usb_impl_init (struct pi_usb_impl *impl)
 	impl->wait_for_device	= u_wait_for_device;
 	impl->changebaud	= NULL;		/* we don't need this one for libusb (yet) */
 	impl->control_request	= u_control_request;
+	impl->interrupt_read = u_interrupt_read;
 }
 
 
@@ -595,6 +598,12 @@ u_control_request (pi_usb_data_t *usb_data, int request_type, int request,
 		int value, int control_index, void *data, int size, int timeout)
 {
 	return usb_control_msg (usb_data->ref, request_type, request, value, control_index, data, size, timeout);
+}
+
+static int
+u_interrupt_read (pi_usb_data_t *usb_data, int ep, void *data, int size, int timeout)
+{
+	return usb_interrupt_read(usb_data->ref, ep, data, size, timeout);
 }
 
 /* vi: set ts=8 sw=4 sts=4 noexpandtab: cin */

--- a/libpisock/linuxusb.c
+++ b/libpisock/linuxusb.c
@@ -66,6 +66,7 @@ void pi_usb_impl_init (struct pi_usb_impl *impl)
 						 * as USB serial adapters redirect to serial ports
 						 */
 	impl->control_request	= NULL;
+	impl->interrupt_read = NULL;
 }
 
 

--- a/libpisock/usb.c
+++ b/libpisock/usb.c
@@ -1035,6 +1035,15 @@ USB_configure_generic (pi_usb_data_t *dev, u_int8_t *input_pipe, u_int8_t *outpu
 	u_int32_t flags = dev->dev.flags;
 
 	ret = dev->impl.control_request (dev, 0xc2, PALM_GET_EXT_CONNECTION_INFORMATION, 0, 0, &ci, sizeof (ci), 0);
+
+	if (ret == 0) {
+		// empty response from PALM_GET_EXT_CONNECTION_INFORMATION, try interrupt (fixes Treo 90)
+		unsigned char buf[64];
+		ret = dev->impl.interrupt_read (dev, 0x82, &buf, sizeof (buf), 0);
+		// 6 first bytes seem to indicate a vendor id, we don't use that yet
+		memcpy(&ci, (buf+6), sizeof (ci));
+	}
+
 	if (ret < 0) {
 		LOG((PI_DBG_DEV, PI_DBG_LVL_ERR, "usb: PALM_GET_EXT_CONNECTION_INFORMATION failed (err=%08x)\n", ret));
 	} else {


### PR DESCRIPTION
This allows hotsyncing with the Treo 90 (and possibly other oddball Palm OS 4.1 PDAs), which informs the USB endpoints for hotsyncing differently.

See also: #13 