### PR TITLE
patch for libpng14 compatibility

### DIFF
--- a/src/pilot-read-notepad.c
+++ b/src/pilot-read-notepad.c
@@ -39,10 +39,6 @@
 
 #ifdef HAVE_PNG
 #include "png.h"
-#if (PNG_LIBPNG_VER < 10201)
- #define png_voidp_NULL (png_voidp)NULL
- #define png_error_ptr_NULL (png_error_ptr)NULL
-#endif
 #endif
 
 const char *progname;
@@ -166,8 +162,8 @@ void write_png( FILE *f, struct NotePad *n )
    width = n->body.width + 8;
 
    png_ptr = png_create_write_struct
-     ( PNG_LIBPNG_VER_STRING, png_voidp_NULL,
-       png_error_ptr_NULL, png_error_ptr_NULL);
+     ( PNG_LIBPNG_VER_STRING, NULL,
+       NULL, NULL);
 
    if(!png_ptr)
      return;

--- a/src/pilot-read-palmpix.c
+++ b/src/pilot-read-palmpix.c
@@ -42,10 +42,6 @@
 
 #ifdef HAVE_PNG
 #include "png.h"
-#if (PNG_LIBPNG_VER < 10201)
- #define png_voidp_NULL (png_voidp)NULL
- #define png_error_ptr_NULL (png_error_ptr)NULL
-#endif
 #endif
 
 const char *progname;
@@ -223,8 +219,8 @@ void write_png( FILE *f, const struct PalmPixState *state,
 	png_infop info_ptr;
 
 	png_ptr = png_create_write_struct
-		( PNG_LIBPNG_VER_STRING, png_voidp_NULL,
-		png_error_ptr_NULL, png_error_ptr_NULL);
+		( PNG_LIBPNG_VER_STRING, NULL,
+		NULL, NULL);
 
 	if(!png_ptr)
 		return;

--- a/src/pilot-read-screenshot.c
+++ b/src/pilot-read-screenshot.c
@@ -40,10 +40,6 @@
 
 #ifdef HAVE_PNG
 # include "png.h"
-# if (PNG_LIBPNG_VER < 10201)
-#  define png_voidp_NULL (png_voidp)NULL
-#  define png_error_ptr_NULL (png_error_ptr)NULL
-# endif
 #endif
 
 #define pi_mktag(c1,c2,c3,c4) (((c1)<<24)|((c2)<<16)|((c3)<<8)|(c4))
@@ -87,8 +83,8 @@ void write_png ( char *fname, struct ss_state *state )
 		gray_buf = malloc( state->w );
 
 	png_ptr = png_create_write_struct
-		(PNG_LIBPNG_VER_STRING, png_voidp_NULL,
-		png_error_ptr_NULL, png_error_ptr_NULL);
+		(PNG_LIBPNG_VER_STRING, NULL,
+		NULL, NULL);
 
 	if (!png_ptr)
 		return;

--- a/src/pilot-read-veo.c
+++ b/src/pilot-read-veo.c
@@ -41,10 +41,6 @@
 
 #ifdef HAVE_PNG
 # include "png.h"
-# if (PNG_LIBPNG_VER < 10201)
-#  define png_voidp_NULL (png_voidp)NULL
-#  define png_error_ptr_NULL (png_error_ptr)NULL
-# endif
 #endif
 
 #define pi_mktag(c1,c2,c3,c4) (((c1)<<24)|((c2)<<16)|((c3)<<8)|(c4))
@@ -856,8 +852,8 @@ void write_png (FILE * f, struct Veo *v, long flags)
    png_infop info_ptr;
 
    png_ptr = png_create_write_struct
-	 (PNG_LIBPNG_VER_STRING, png_voidp_NULL,
-	  png_error_ptr_NULL, png_error_ptr_NULL);
+	 (PNG_LIBPNG_VER_STRING, NULL,
+	  NULL, NULL);
 
    if (!png_ptr)
 	 return;


### PR DESCRIPTION
Applying Arch Linux patch to fix compilation on modern systems using libpng14: https://aur.archlinux.org/cgit/aur.git/plain/pilot-link-png14.patch?h=pilot-link

See #2 