### PR TITLE
Updating for proper manpage builds

### DIFF
--- a/doc/xml/catalog.xml.in
+++ b/doc/xml/catalog.xml.in
@@ -5,13 +5,13 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
         <nextCatalog catalog="@XML_CATALOG@" />
         @CAT_ENTRY_START@
-        <uri name="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"
+        <uri name="https://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"
                 uri="@DOCBOOK_ROOT@/html/docbook.xsl"/>
-        <uri name="http://docbook.sourceforge.net/release/xsl/current/manpages/synop.xsl"
+        <uri name="https://docbook.sourceforge.net/release/xsl/current/manpages/synop.xsl"
                 uri="@DOCBOOK_ROOT@/manpages/synop.xsl"/>
-        <uri name="http://docbook.sourceforge.net/release/xsl/current/manpages/lists.xsl"
+        <uri name="https://docbook.sourceforge.net/release/xsl/current/manpages/lists.xsl"
                 uri="@DOCBOOK_ROOT@/manpages/lists.xsl"/>
-        <uri name="http://docbook.sourceforge.net/release/xsl/current/manpages/xref.xsl"
+        <uri name="https://docbook.sourceforge.net/release/xsl/current/manpages/xref.xsl"
                 uri="@DOCBOOK_ROOT@/manpages/xref.xsl"/>
         @CAT_ENTRY_END@
         <uri name="manpages/docbook.xsl" uri="@top_srcdir@/doc/xml/docbook.xsl"/>

--- a/doc/xml/docbook.xsl.in
+++ b/doc/xml/docbook.xsl.in
@@ -4,8 +4,8 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version='1.0'>
 
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl"/>
-<xsl:include href="http://docbook.sourceforge.net/release/xsl/current/manpages/synop.xsl"/>
+<xsl:import href="/usr/share/xml/docbook/stylesheet/docbook-xsl/html/docbook.xsl"/>
+<xsl:include href="/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/synop.xsl"/>
 
 <!-- Needed for chunker.xsl (for now): -->
 <xsl:param name="chunker.output.method" select="'text'"/>


### PR DESCRIPTION
Simple fixes to address the building of manpages using modern `xsltproc` and changes to upstream DocBook XSL paths and URIs. 